### PR TITLE
Improve 4040 method algorithm

### DIFF
--- a/src/main/java/fhannenheim/autopilot/flight/FlightExecutor.java
+++ b/src/main/java/fhannenheim/autopilot/flight/FlightExecutor.java
@@ -64,11 +64,9 @@ public class FlightExecutor {
         this.currentVelocity = getVelocity(playerEntity);
 
         if (this.isDescending) {
-            Autopilot.LOGGER.warn("here3");
             this.pullUp = false;
             this.pullDown = true;
             if (this.currentVelocity >= this.config.pullDownMaxVelocity) {
-                Autopilot.LOGGER.warn("here1");
                 this.isDescending = false;
                 this.pullDown = false;
                 this.pullUp = true;

--- a/src/main/java/fhannenheim/autopilot/flight/FlightExecutor.java
+++ b/src/main/java/fhannenheim/autopilot/flight/FlightExecutor.java
@@ -3,6 +3,7 @@ package fhannenheim.autopilot.flight;
 import com.sun.javafx.geom.Vec2d;
 import fhannenheim.autopilot.Autopilot;
 import fhannenheim.autopilot.util.Config;
+import fhannenheim.autopilot.util.ElytraConfig;
 import fhannenheim.autopilot.util.InventoryUtils;
 import fhannenheim.autopilot.util.SpecialActions;
 import net.minecraft.client.Minecraft;
@@ -10,12 +11,19 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.play.client.CPlayerTryUseItemPacket;
 import net.minecraft.util.Hand;
 import net.minecraft.util.SoundEvents;
+import net.minecraftforge.client.MinecraftForgeClient;
 
 public class FlightExecutor {
     public FlightHandler flightHandler;
     public int ticksSinceRocket;
     private FlightPhase flightPhase;
     public boolean preventRocket;
+
+    public boolean isDescending;
+    public boolean pullDown;
+    public boolean pullUp;
+    public double currentVelocity;
+    public ElytraConfig config = new ElytraConfig();
 
     public FlightExecutor(FlightHandler flightHandler) {
         this.flightHandler = flightHandler;
@@ -53,33 +61,43 @@ public class FlightExecutor {
 
     // values from https://www.reddit.com/r/Minecraft/comments/5ic9la/using_a_genetic_algorithm_to_power_infinite/
     public void fourtyfourtyFlight(PlayerEntity playerEntity) {
-        // Place new rockets in hand if needed
-        InventoryUtils.refillRockets(playerEntity);
+        this.currentVelocity = getVelocity(playerEntity);
 
-        // apparently switch statements can't handle null-objects
-        flightPhase = flightPhase == null ? FlightPhase.DESCEND : flightPhase;
-
-        switch (flightPhase) {
-            case ASCEND:
-                playerEntity.rotationPitch = -49.44969f;
-                break;
-            case DESCEND:
-                playerEntity.rotationPitch = 37.7458839f;
-                break;
-            default:
-                flightPhase = FlightPhase.DESCEND;
-                break;
+        if (this.isDescending) {
+            Autopilot.LOGGER.warn("here3");
+            this.pullUp = false;
+            this.pullDown = true;
+            if (this.currentVelocity >= this.config.pullDownMaxVelocity) {
+                Autopilot.LOGGER.warn("here1");
+                this.isDescending = false;
+                this.pullDown = false;
+                this.pullUp = true;
+            }
+        } else {
+            this.pullUp = true;
+            this.pullDown = false;
+            if (this.currentVelocity <= this.config.pullUpMinVelocity) {
+                this.isDescending = true;
+                this.pullDown = true;
+                this.pullUp = false;
+            }
         }
 
-        double velocity = getVelocity(playerEntity);
-        if (flightPhase == FlightPhase.DESCEND && velocity > 2.08719635f)
-            flightPhase = FlightPhase.ASCEND;
-        else if (flightPhase == FlightPhase.ASCEND && velocity < 0.224041611f)
-            flightPhase = FlightPhase.DESCEND;
-        if (flightPhase == FlightPhase.ASCEND && playerEntity.getPosY() < Config.flight_level.get() && velocity < 0.75f) {
-            useRocket();
-            ticksSinceRocket = 0;
+
+        if (this.pullUp) {
+            playerEntity.rotationPitch = (float)((double)playerEntity.rotationPitch - this.config.pullUpSpeed);
+            if ((double)playerEntity.rotationPitch <= this.config.pullUpAngle) {
+                playerEntity.rotationPitch = (float)this.config.pullUpAngle;
+            }
         }
+
+        if (this.pullDown) {
+            playerEntity.rotationPitch = (float)((double)playerEntity.rotationPitch + this.config.pullDownSpeed);
+            if ((double)playerEntity.rotationPitch >= this.config.pullDownAngle) {
+                playerEntity.rotationPitch = (float)this.config.pullDownAngle;
+            }
+        }
+
         if (flightHandler.destination != null && Vec2d.distance(flightHandler.destination.x, flightHandler.destination.z, playerEntity.getPosX(), playerEntity.getPosZ()) < 3) {
             if (Config.on_arrive.get() == SpecialActions.Disconnect) {
                 flightHandler.shallDisconnect = true;

--- a/src/main/java/fhannenheim/autopilot/flight/FlightHandler.java
+++ b/src/main/java/fhannenheim/autopilot/flight/FlightHandler.java
@@ -52,6 +52,10 @@ public class FlightHandler {
                 if (rockets) flightType = FlightType.ROCKETS;
                 else flightType = FlightType.ANGLE4040;
                 isAutoFlying = true;
+
+                if (isAutoFlying && flightType == FlightType.ANGLE4040) {
+                    flightExecutor.isDescending = true;
+                }
             } else {
                 isAutoFlying = false;
             }

--- a/src/main/java/fhannenheim/autopilot/util/ElytraConfig.java
+++ b/src/main/java/fhannenheim/autopilot/util/ElytraConfig.java
@@ -1,0 +1,19 @@
+package fhannenheim.autopilot.util;
+
+public class ElytraConfig {
+    public int guiX = 5;
+    public int guiY = 5;
+    public int guiWidth = 150;
+    public int guiHeight = 50;
+    public int guiGraphRealWidth = 2000;
+    public boolean showGraph = true;
+    public double pullUpAngle = -46.633514D;
+    public double pullDownAngle = 37.19872D;
+    public double pullUpMinVelocity = 1.9102669D;
+    public double pullDownMaxVelocity = 2.3250866D;
+    public double pullUpSpeed = 6.4815372D;
+    public double pullDownSpeed = 0.61635801D;
+
+    public ElytraConfig() {
+    }
+}


### PR DESCRIPTION
This PR modifies the previous 4040 algorithm to utilize the algorithm [this mod](https://www.curseforge.com/minecraft/mc-mods/elytra-auto-flight) uses. 

The values and incremental pitch changes this mod uses result in smoother flight and an approx 10m gain in altitude per cycle without the use of any rockets.

ie, using this method is now completely free except for elytra damage.

If someone stumbles across this looking for a compiled version of this for 1.16.4, I made one [here](https://chimneyswift.pro/media/2020/11/28/autopilot-1.0.jar)